### PR TITLE
Avoid exception on audio_channels method

### DIFF
--- a/lib/rvideo/inspector.rb
+++ b/lib/rvideo/inspector.rb
@@ -400,7 +400,7 @@ module RVideo # :nodoc:
       when "stereo"
         2
       else
-        raise RuntimeError, "Unknown number of channels: #{audio_channels}"
+        raise RuntimeError, "Unknown number of channels: #{audio_match[5]}"
       end
     end
     

--- a/lib/rvideo/inspector.rb
+++ b/lib/rvideo/inspector.rb
@@ -393,6 +393,7 @@ module RVideo # :nodoc:
     
     def audio_channels
       return nil unless audio?
+      return audio_match[5].to_i if (audio_match[5].to_i > 0)
 
       case audio_match[5]
       when "mono"
@@ -523,7 +524,7 @@ module RVideo # :nodoc:
     def audio_match
       return nil unless valid?
       
-      /Stream\s*(.*?)[,|:|\(|\[].*?\s*Audio:\s*(.*?),\s*([0-9\.]*) (\w*),\s*([a-zA-Z:]*)/.match(audio_stream)
+      /Stream\s*(.*?)[,|:|\(|\[].*?\s*Audio:\s*(.*?),\s*([0-9\.]*) (\w*),\s*([(\d)*a-zA-Z:]*)/.match(audio_stream)
     end
 
     def video_match


### PR DESCRIPTION
This commit fixes a "Stack level too deep" exception when running into the else on the case statement.
The exception message was calling this method again, making it an infinite loop.
